### PR TITLE
Fix the condition in canFocusRowAt

### DIFF
--- a/Sources/TVOSPicker/TVOSPickerComponentView.swift
+++ b/Sources/TVOSPicker/TVOSPickerComponentView.swift
@@ -278,7 +278,7 @@ extension TVOSPickerComponentView: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, canFocusRowAt indexPath: IndexPath) -> Bool {
-        if !focusInside, let selected = tableView.indexPathForSelectedRow {
+        if !focusInside, !isFastScrolling, let selected = tableView.indexPathForSelectedRow {
             return indexPath == selected
         }
         return rangeOfAllowedIndices?.contains(indexPath.item) ?? true


### PR DESCRIPTION
focusInside flips to false when fast scrolling mode activates so we need to check isFastScrolling as well, otherwise, after fast scroll, the table view might no longer accept focus